### PR TITLE
Ctrl-C support

### DIFF
--- a/aiomultiprocess/tests/base.py
+++ b/aiomultiprocess/tests/base.py
@@ -48,6 +48,10 @@ async def raise_fn():
     raise RuntimeError("raising")
 
 
+async def raise_keyboard_interrupt():
+    raise KeyboardInterrupt()
+
+
 async def terminate(process):
     await asyncio.sleep(0.5)
     process.terminate()

--- a/aiomultiprocess/tests/core.py
+++ b/aiomultiprocess/tests/core.py
@@ -14,6 +14,7 @@ from .base import (
     get_dummy_constant,
     initializer,
     raise_fn,
+    raise_keyboard_interrupt,
     sleepy,
     two,
 )
@@ -222,6 +223,13 @@ class CoreTest(TestCase):  # pylint: disable=too-many-public-methods
             target=raise_fn, name="test_process", initializer=do_nothing
         )
         self.assertIsInstance(result, RuntimeError)
+
+    @async_test
+    async def test_keyboard_interrupt(self):
+        result = await amp.Worker(
+            target=raise_keyboard_interrupt, name="test_process", initializer=do_nothing
+        )
+        self.assertIsNone(result)
 
     @async_test
     async def test_sync_target(self):


### PR DESCRIPTION
### Description

Code to replicate issue:

(run and press Ctrl+C)
```python
import asyncio
import time
import aiomultiprocess

async def _main():
    # not reproducible with small number of processes
    async with aiomultiprocess.Pool(20):
        time.sleep(99999)

if __name__ == '__main__':
    try:
        asyncio.run(_main())
    except KeyboardInterrupt:
        pass
```
You will see a lot of stack traces like:
```
Traceback (most recent call last):
  File "/Users/user/venv/lib/python3.8/site-packages/aiomultiprocess/core.py", line 143, in run_async
    result: R = loop.run_until_complete(unit.target(*unit.args, **unit.kwargs))
  File "/Users/user/.pyenv/versions/3.8.5/lib/pyaio process 33621 failed
Traceback (most recent call last):
  File "/Users/user/venv/lib/python3.8/site-packages/aiomultiprocess/core.py", line 143, in run_async
    result: R = loop.run_until_complete(unit.target(*unit.args, **unit.kwargs))
  File "/Users/user/.pyenv/versions/3.8.5/lib/python3.8/asyncio/base_events.py", line 603, in run_until_complete
    self.run_forever()
  File "/Users/user/.pyenv/versions/3.8.5/lib/python3.8/asyncio/base_events.py", line 570, in run_forever
    self._run_once()
  File "/Users/user/.pyenv/versions/3.8.5/lib/python3.8/asyncio/base_events.py", line 1823, in _run_once
    event_list = self._selector.select(timeout)
  File "/Users/user/.pyenv/versions/3.8.5/lib/python3.8/selectors.py", line 558, in select
    kev_list = self._selector.control(None, max_ev, timeout)
KeyboardInterrupt
aio process 33627 failed
```
----
This PR is supposed to solve this problem.

