### PR TITLE
astroid.exceptions.DuplicateBasesError: Duplicates found in MROs (PoolResult)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,8 @@ black==20.8b1
 codecov==2.1.10
 coverage==5.3
 mypy==0.790
-pylint==2.7.0
+pylint==2.6.0
+astroid==2.4.2
 python-coveralls==2.9.3
 sphinx==3.3.0
 twine==3.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,8 +3,8 @@ black==20.8b1
 codecov==2.1.10
 coverage==5.3
 mypy==0.790
-pylint==2.6.0
-astroid==2.4.2
+pylint==2.7.2
+astroid==2.5.1
 python-coveralls==2.9.3
 sphinx==3.3.0
 twine==3.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ black==20.8b1
 codecov==2.1.10
 coverage==5.3
 mypy==0.790
-pylint==2.6.0
+pylint==2.7.0
 python-coveralls==2.9.3
 sphinx==3.3.0
 twine==3.2.0


### PR DESCRIPTION
There's a new CI error on py 3.7 & 3.8 CI, pylint simply dies inside astroid.
```
python -m pylint --rcfile .pylint aiomultiprocess setup.py
```

```
Traceback (most recent call last):
  File "/astroid/decorators.py", line 34, in cached
    return cache[func]
KeyError: <bound method ClassDef.slots of <ClassDef.PoolResult l.116 at 0x102e2f280>>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/__main__.py", line 18, in <module>
    pylint.run_pylint()
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/__init__.py", line 22, in run_pylint
    PylintRun(sys.argv[1:])
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/lint/run.py", line 349, in __init__
    linter.check(args)
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 862, in check
    self._check_files(
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 896, in _check_files
    self._check_file(get_ast, check_astroid_module, name, filepath, modname)
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 922, in _check_file
    check_astroid_module(ast_node)
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 1054, in check_astroid_module
    retval = self._check_astroid_module(
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/lint/pylinter.py", line 1099, in _check_astroid_module
    walker.walk(ast_node)
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/utils/ast_walker.py", line 75, in walk
    self.walk(child)
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/utils/ast_walker.py", line 72, in walk
    callback(astroid)
  File "/aiomultiprocess/lib/python3.8/site-packages/pylint/checkers/variables.py", line 1203, in visit_importfrom
    module = node.do_import_module(name_parts[0])
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/mixins.py", line 99, in do_import_module
    return mymodule.import_module(
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/scoped_nodes.py", line 646, in import_module
    return MANAGER.ast_from_module_name(absmodname)
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/manager.py", line 191, in ast_from_module_name
    return self.ast_from_file(found_spec.location, modname, fallback=False)
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/manager.py", line 100, in ast_from_file
    return AstroidBuilder(self).file_build(filepath, modname)
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/builder.py", line 139, in file_build
    return self._post_build(module, encoding)
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/builder.py", line 159, in _post_build
    self.delayed_assattr(delayed)
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/builder.py", line 235, in delayed_assattr
    if not _can_assign_attr(inferred, node.attrname):
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/builder.py", line 60, in _can_assign_attr
    slots = node.slots()
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/decorators.py", line 36, in cached
    cache[func] = result = func(*args, **kwargs)
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/scoped_nodes.py", line 2838, in slots
    slots = list(grouped_slots())
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/scoped_nodes.py", line 2823, in grouped_slots
    for cls in self.mro()[:-1]:
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/scoped_nodes.py", line 2909, in mro
    return self._compute_mro(context=context)
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/scoped_nodes.py", line 2898, in _compute_mro
    unmerged_mro = list(clean_duplicates_mro(unmerged_mro, self, context))
  File "/aiomultiprocess/lib/python3.8/site-packages/astroid/scoped_nodes.py", line 110, in clean_duplicates_mro
    raise exceptions.DuplicateBasesError(
astroid.exceptions.DuplicateBasesError: Duplicates found in MROs (PoolResult), (_GenericAlias, _Final, object), (_GenericAlias, _Final, object), (_GenericAlias, _GenericAlias) for <ClassDef.PoolResult l.116 at 0x102e2f280>.
```