### PR TITLE
Adding Connection Pool functionality to pool workers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,6 +8,6 @@ ignore =
     E2
     E3
     E4
-max-line-length = 88
+max-line-length = 112
 per-file-ignores =
     __init__.py: F401

--- a/aiomultiprocess/pool.py
+++ b/aiomultiprocess/pool.py
@@ -20,9 +20,11 @@ from typing import (
     TypeVar,
 )
 
+from aiohttp import ClientSession, ClientTimeout, TCPConnector
+
 from .core import Process, get_context
 from .scheduler import RoundRobin, Scheduler
-from .types import LoopInitializer, PoolTask, ProxyException, Queue, QueueID, R, Session, T, TaskID, TracebackStr
+from .types import LoopInitializer, PoolTask, ProxyException, Queue, QueueID, R, T, TaskID, TracebackStr
 
 MAX_TASKS_PER_CHILD = 0  # number of tasks to execute before recycling a child process
 CHILD_CONCURRENCY = 16  # number of tasks to execute simultaneously per child process
@@ -45,8 +47,8 @@ class PoolWorker(Process):
         initargs: Sequence[Any] = (),
         loop_initializer: Optional[LoopInitializer] = None,
         exception_handler: Optional[Callable[[BaseException], None]] = None,
-        client_session: Optional[Session] = None,
-        session_kwargs: Optional[dict] = None,
+        init_client_session: bool = False,
+        session_base_url: Optional[str] = None,
     ) -> None:
         super().__init__(
             target=self.run,
@@ -56,19 +58,24 @@ class PoolWorker(Process):
         )
         self.concurrency = max(1, concurrency)
         self.exception_handler = exception_handler
-        self.client_session = client_session
-        self.session_kwargs = session_kwargs
+        self.init_client_session = init_client_session
+        self.session_base_url = session_base_url
         self.ttl = max(0, ttl)
         self.tx = tx
         self.rx = rx
 
-    def _init_client_session(self) -> Session:
+    def _init_client_session(self) -> ClientSession:
         """Initialize a client session for this worker."""
-        return self.client_session(**self.session_kwargs) if self.client_session else None
+        pass
+        # return
 
     async def run(self) -> None:
         """Initiate a connection pool, pick up work, execute work, return results, rinse, repeat."""
-        async with self._init_client_session() as client_session:
+        async with ClientSession(
+            connector=TCPConnector(limit_per_host=max(100, self.concurrency), use_dns_cache=True),
+            timeout=ClientTimeout(total=60),
+            base_url=self.session_base_url if self.session_base_url else None,
+        ) as client_session:
             pending: Dict[asyncio.Future, TaskID] = {}
             completed = 0
             running = True
@@ -89,10 +96,7 @@ class PoolWorker(Process):
                         break
 
                     tid, func, args, kwargs = task
-
-                    # NOTE: adds client session to the args list
-                    if self.client_session:
-                        args = [*args, client_session]
+                    args = [*args, client_session]  # NOTE: adds client session to the args list
                     future = asyncio.ensure_future(func(*args, **kwargs))
                     pending[future] = tid
 

--- a/aiomultiprocess/pool.py
+++ b/aiomultiprocess/pool.py
@@ -160,8 +160,8 @@ class Pool:
         scheduler: Scheduler = None,
         loop_initializer: Optional[LoopInitializer] = None,
         exception_handler: Optional[Callable[[BaseException], None]] = None,
-        client_session: Session = True,
-        session_kwargs: Optional[dict] = None,
+        init_client_session: bool = True,
+        session_base_url: Optional[str] = None,
     ) -> None:
         self.context = get_context()
 
@@ -178,8 +178,8 @@ class Pool:
         self.maxtasksperchild = max(0, maxtasksperchild)
         self.childconcurrency = max(1, childconcurrency)
         self.exception_handler = exception_handler
-        self.client_session = client_session
-        self.session_kwargs = session_kwargs
+        self.init_client_session = init_client_session
+        self.session_base_url = session_base_url
 
         self.processes: Dict[Process, QueueID] = {}
         self.queues: Dict[QueueID, Tuple[Queue, Queue]] = {}
@@ -262,8 +262,8 @@ class Pool:
             initargs=self.initargs,
             loop_initializer=self.loop_initializer,
             exception_handler=self.exception_handler,
-            client_session=self.client_session,
-            session_kwargs=self.session_kwargs,
+            init_client_session=self.init_client_session,
+            session_base_url=self.session_base_url,
         )
         process.start()
         return process

--- a/aiomultiprocess/pool.py
+++ b/aiomultiprocess/pool.py
@@ -160,8 +160,8 @@ class Pool:
         scheduler: Scheduler = None,
         loop_initializer: Optional[LoopInitializer] = None,
         exception_handler: Optional[Callable[[BaseException], None]] = None,
-        init_client_session: bool = True,
-        session_base_url: Optional[str] = None,
+        client_session: Session = True,
+        session_kwargs: Optional[dict] = None,
     ) -> None:
         self.context = get_context()
 
@@ -178,8 +178,8 @@ class Pool:
         self.maxtasksperchild = max(0, maxtasksperchild)
         self.childconcurrency = max(1, childconcurrency)
         self.exception_handler = exception_handler
-        self.init_client_session = init_client_session
-        self.session_base_url = session_base_url
+        self.client_session = client_session
+        self.session_kwargs = session_kwargs
 
         self.processes: Dict[Process, QueueID] = {}
         self.queues: Dict[QueueID, Tuple[Queue, Queue]] = {}
@@ -262,8 +262,8 @@ class Pool:
             initargs=self.initargs,
             loop_initializer=self.loop_initializer,
             exception_handler=self.exception_handler,
-            init_client_session=self.init_client_session,
-            session_base_url=self.session_base_url,
+            client_session=self.client_session,
+            session_kwargs=self.session_kwargs,
         )
         process.start()
         return process

--- a/aiomultiprocess/pool.py
+++ b/aiomultiprocess/pool.py
@@ -98,7 +98,7 @@ class PoolWorker(Process):
 
                 tid, func, args, kwargs = task
                 if self.client_session:
-                    args = [self.client_session, *args]
+                    args = [self.client_session, *args]  # NOTE: adds client session to the args list
                 future = asyncio.ensure_future(func(*args, **kwargs))
                 pending[future] = tid
 

--- a/aiomultiprocess/types.py
+++ b/aiomultiprocess/types.py
@@ -1,19 +1,6 @@
-# Copyright 2022 Amethyst Reese
-# Licensed under the MIT license
-
 import multiprocessing
 from asyncio import BaseEventLoop
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    NamedTuple,
-    NewType,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-)
+from typing import Any, Callable, Dict, NamedTuple, NewType, Optional, Sequence, Tuple, TypeVar
 
 T = TypeVar("T")
 R = TypeVar("R")

--- a/aiomultiprocess/types.py
+++ b/aiomultiprocess/types.py
@@ -1,5 +1,5 @@
 import multiprocessing
-from asyncio import BaseEventLoop, BaseProtocol
+from asyncio import BaseEventLoop
 from typing import Any, Callable, Dict, NamedTuple, NewType, Optional, Sequence, Tuple, TypeVar
 
 T = TypeVar("T")
@@ -16,8 +16,6 @@ TracebackStr = str
 LoopInitializer = Callable[..., BaseEventLoop]
 PoolTask = Optional[Tuple[TaskID, Callable[..., R], Sequence[T], Dict[str, T]]]
 PoolResult = Tuple[TaskID, Optional[R], Optional[TracebackStr]]
-
-Session = NewType("Session", BaseProtocol)
 
 
 class Unit(NamedTuple):

--- a/aiomultiprocess/types.py
+++ b/aiomultiprocess/types.py
@@ -1,5 +1,5 @@
 import multiprocessing
-from asyncio import BaseEventLoop
+from asyncio import BaseEventLoop, BaseProtocol
 from typing import Any, Callable, Dict, NamedTuple, NewType, Optional, Sequence, Tuple, TypeVar
 
 T = TypeVar("T")
@@ -16,6 +16,8 @@ TracebackStr = str
 LoopInitializer = Callable[..., BaseEventLoop]
 PoolTask = Optional[Tuple[TaskID, Callable[..., R], Sequence[T], Dict[str, T]]]
 PoolResult = Tuple[TaskID, Optional[R], Optional[TracebackStr]]
+
+Session = NewType("Session", BaseProtocol)
 
 
 class Unit(NamedTuple):


### PR DESCRIPTION
### Description

Aiomultiprocess is exceptionally good at scaling network requests. However, the abstraction of tasks to queues scheduled amongst pool workers makes it impossible to enable connection pools for each worker in the current state. Using aiohttp's requests method results in a new session being created for every request, which degrades performance. 

This PR nests each pool workers target `.run()` function within an async context manager that creates an aiohttp clientsession and passes the session into the tasks args. 

The PR in its current state will need some clean up before it is ready for merge, but I wanted to submit as a WIP to see if a contribution such as this would even be considered.
