### PR TITLE
use Iterable[T] instead of Sequence[T] in Pool.map iterable

### DIFF
--- a/aiomultiprocess/pool.py
+++ b/aiomultiprocess/pool.py
@@ -14,6 +14,7 @@ from typing import (
     Callable,
     Dict,
     Generator,
+    Iterable,
     Optional,
     Sequence,
     Tuple,
@@ -333,7 +334,7 @@ class Pool:
     def map(
         self,
         func: Callable[[T], Awaitable[R]],
-        iterable: Sequence[T],
+        iterable: Iterable[T],
         # chunksize: int = None,  # todo: implement chunking maybe
     ) -> PoolResult[R]:
         """Run a coroutine once for each item in the iterable."""


### PR DESCRIPTION
First off: Thank you very much for this package! :)

Here's a little thing about type hints I found.
In essence the Sequece type is too restrictive. The function map can deal as is with any iterable.

### Description

The type of the arg `iterable` should be a `Iterable` instead of `Sequence`.
Here's pyright hint:

![pyright-error](https://github.com/user-attachments/assets/64a8b720-0565-42f9-9bd0-1f312fe4dd3c)


And here's after the fix

![pyright-noerror](https://github.com/user-attachments/assets/cd4d07d7-b596-4386-8621-ed566664a799)
