### PR TITLE
Make Process joining less likely to block

### DIFF
--- a/aiomultiprocess/core.py
+++ b/aiomultiprocess/core.py
@@ -9,7 +9,6 @@ import multiprocessing.managers
 import os
 import sys
 from typing import Any, Callable, Dict, Optional, Sequence
-
 from .types import Context, R, Unit
 
 DEFAULT_START_METHOD = "spawn"
@@ -114,7 +113,7 @@ class Process:
             initargs=initargs,
             loop_initializer=loop_initializer,
         )
-        self.aio_process = context.Process(  # type: ignore[attr-defined]
+        self.aio_process: multiprocessing.Process = context.Process(  # type: ignore[attr-defined]
             group=group,
             target=process_target or Process.run_async,
             args=(self.unit,),
@@ -159,12 +158,13 @@ class Process:
         """Wait for the process to finish execution without blocking the main thread."""
         if not self.is_alive() and self.exitcode is None:
             raise ValueError("must start process before joining it")
+        
+        # TODO: Something more fine-tuned or find a way to hook
+        # a callback to signal to indicate that the process finished.
+        return await asyncio.to_thread(self.aio_process.join, timeout)
 
-        if timeout is not None:
-            return await asyncio.wait_for(self.join(), timeout)
 
-        while self.exitcode is None:
-            await asyncio.sleep(0.005)
+        
 
     @property
     def name(self) -> str:

--- a/aiomultiprocess/core.py
+++ b/aiomultiprocess/core.py
@@ -158,10 +158,12 @@ class Process:
         """Wait for the process to finish execution without blocking the main thread."""
         if not self.is_alive() and self.exitcode is None:
             raise ValueError("must start process before joining it")
+
+        if timeout:
+            return await asyncio.wait_for(self.join, timeout)
         
-        # TODO: Something more fine-tuned or find a way to hook
-        # a callback to signal to indicate that the process finished.
-        return await asyncio.to_thread(self.aio_process.join, timeout)
+        while self.exitcode is None:
+            await asyncio.to_thread(self.aio_process.join, 0.005)
 
 
         


### PR DESCRIPTION
### Description

In an attempt to make the asynchronous portions of this library less reliant on polling I decided to try seeing if there were other more fine tuned ways to go about checking to see if a process was closed. I plan to try making it so that a callback could be hooked in the future or see if there are any ways to hook in a listener for a pid to be closed but here is the best I could come up with. I'll try to see about finding other alternative solutions to more await asyncio.sleep(0.005) lines of code soon but this is a start with what I had in mind. 

~~I may change this so threat it for right now as a draft or a DNM (Do not merge)~~

Edit: it's ready
